### PR TITLE
Update link to docker-run binary from version 1.3.0 to 1.4.0

### DIFF
--- a/docs/install/ubuntu-20.10.md
+++ b/docs/install/ubuntu-20.10.md
@@ -28,7 +28,7 @@ usermod -aG docker glot
 ```bash
 mkdir /home/glot/bin
 cd /home/glot/bin
-wget https://github.com/glotcode/docker-run/releases/download/v1.3.0/docker-run_linux-x64.tar.gz
+wget https://github.com/glotcode/docker-run/releases/download/v1.4.0/docker-run_linux-x64.tar.gz
 tar -zxf docker-run_linux-x64.tar.gz
 rm docker-run_linux-x64.tar.gz
 chown -R glot:glot /home/glot/bin

--- a/docs/install/ubuntu-20.10.md
+++ b/docs/install/ubuntu-20.10.md
@@ -28,7 +28,7 @@ usermod -aG docker glot
 ```bash
 mkdir /home/glot/bin
 cd /home/glot/bin
-wget https://github.com/glotcode/docker-run/releases/download/v1.4.0/docker-run_linux-x64.tar.gz
+wget https://github.com/glotcode/docker-run/releases/download/v.1.4.0/docker-run_linux-x64.tar.gz
 tar -zxf docker-run_linux-x64.tar.gz
 rm docker-run_linux-x64.tar.gz
 chown -R glot:glot /home/glot/bin


### PR DESCRIPTION
The install instruction doesn't use the most resent version of docker-run